### PR TITLE
little bugfix

### DIFF
--- a/models/gr4j_cemaneige.py
+++ b/models/gr4j_cemaneige.py
@@ -179,7 +179,7 @@ def simulation(data, params):
         StUH1[NH-1] = OrdUH1[NH-1] * PRHU1
 
         # convolution of unit hydrograph UH2
-        for k in range(int( max(1, min(2*NH-1, 2*int(X4+1))) )):
+        for k in range(int( max(1, min(2*NH-1, 2*int(X4)+1)) )):
             StUH2[k] = StUH2[k+1] + OrdUH2[k] * PRHU2
         StUH2[2*NH-1] = OrdUH2[2*NH-1] * PRHU2
 


### PR DESCRIPTION
- the number of ordinates for the 2nd unit hydrograph should be 2*x4 + 1 not 2*(x4+1) ( see page 279 top left of C. Perrin et al. 2003)